### PR TITLE
Handle debugReports field in response

### DIFF
--- a/draft-ietf-bidding-and-auction-services.md
+++ b/draft-ietf-bidding-and-auction-services.md
@@ -393,7 +393,8 @@ in order to communicate with the Bidding and Auction services.
 
 This algorithm takes as input all of the `relevant interest groups`, and a config
 consisting of the `publisher`,
-an optional `desired total size`, an optional list of `interest group owners` to
+an optional `desired total size`, an optional boolean `debugging report locked out`
+defaults to false, an optional list of `interest group owners` to
 include each with an optional `desired size`, and the [HPKE] `public key` and
 its associated `key ID`. It returns an `encrypted request` and a `request context`
 tuple.
@@ -411,7 +412,7 @@ tuple.
 1. Construct a request, `request` with `request["publisher"]` set to `publisher`,
    `request["version"]` set to 0, `request["generationId"]` set to a new [UUID]
    [Version 4](https://www.rfc-editor.org/rfc/rfc9562.html#section-5.4),
-   and `request["enableDebugReporting"]` set to true.
+   and `request["enableDebugReporting"]` set to `debugging report locked out`.
 1. Set `current_size` to be the serialized size of the encrypted request
    created from `request` without padding.
 1. Set `remaining_allocated_size` to 0.
@@ -778,12 +779,8 @@ response = {
   ; If not present, map as Null.
   ? buyerAndSellerReportingId: tstr,
 
-  ; Optional SelectedBuyerAndSellerReportingId of the winning Ad
-  ; Maps directly to https://wicg.github.io/turtledove/#server-auction-response-selected-buyer-and-seller-reporting-id
-  ; If not present, map as Null.
-  ? selectedBuyerAndSellerReportingId: tstr,
-
   ; The auction result may be ignored if set to true.
+  ; Maps to https://wicg.github.io/turtledove/#server-auction-response-is-chaff.
   ; If not present, map as false.
   ? isChaff: bool,
 
@@ -822,6 +819,23 @@ response = {
   ; Maps directly to https://wicg.github.io/turtledove/#server-auction-response-top-level-seller.
   ; If not present, map as Null.
   ? topLevelSeller: origin,
+
+  ; Optional list of forDebuggingOnly reports.
+  ; If not present, map as an empty list.
+  ; Maps to https://wicg.github.io/turtledove/#server-auction-response-component-win-debugging-only-reports
+  ; and https://wicg.github.io/turtledove/#server-auction-response-server-filtered-debugging-only-reports.
+  ? debugReports: [
+    * {
+      origin => [
+        * {
+          url tstr,
+          ? bool isWinReport,
+          ? bool isSellerReport,
+          ? bool componentWin
+        }
+      ]
+    }
+  ],
 }
 
 ; Defines the structure for reporting URLs.
@@ -978,15 +992,40 @@ response from Bidding and Auction Services. It takes as input the
      parsed as a [URL], returning failure if there is an error.
 1. If `response["adMetadata"]` exists and is a string set
    `processed response["ad metadata"]` to `response["adMetadata"]`.
-1. If `response["buyerReportingId"]` exists and is a string, set
+1. If `response["buyerReportingId"]` exists and is a string set
    `processed response["buyer reporting id"]` to `response["buyerReportingId"]`.
-1. If `response["buyerAndSellerReportingId"]` exists and is a string, set
+1. If `response["buyerAndSellerReportingId"]` exists and is a string set
    `processed response["buyer and seller reporting id"]` to
    `response["buyerAndSellerReportingId"]`.
-1. If `response["selectedBuyerAndSellerReportingId"]` exists and is a string, set
-   `processed response["selected buyer and seller reporting id"]` to
-   `response["selectedBuyerAndSellerReportingId"]`.
-
+1. If `response["debugReports"]` exists and is an array:
+   1. For each `per origin debug reports` in `response["debugReports"]`:
+      1. If `per origin debug reports["adTechOrigin"]` does not exist or is not a string,
+         continue with the next iteration.
+      1. Let `ad tech origin` be `per origin debug reports["adTechOrigin"]` parsed as an [ORIGIN],
+         continue with the next iteration if there is an error.
+      1. If `per origin debug reports["reports"]` does not exist or is not an array,
+         continue with the next iteration.
+      1. For each `report` in `per origin debug reports["reports"]`:
+         1. If `report` is not a map, continue with the next iteration.
+         1. Let `component win` be `report["componentWin"]` if it exists and is a bool,
+            otherwise false.
+         1. If `report["url"]` exists and is a string:
+            1. Let `url` be `report["url"]` parsed as a [URL], or continue with the next
+               iteration if there is an error.
+            1. If `component win` is false, set
+               `processed response["server filtered debugging only reports"][ad tech origin]` to `url`,
+               and continue with the next iteration.
+            1. Let `debug report key` be a new structure analogous to
+               [server auction debug report key](https://wicg.github.io/turtledove/#server-auction-debug-report-key).
+            1. Set `debug report key["from seller"]` to `report["isSellerReport"]` if it exists and is a bool,
+               otherwise false.
+            1. Set `debug report key["is debug win"]` to `report["isWinReport"]` if it exists and is a bool,
+               otherwise false. 
+            1. Set `processed response["component win debugging only reports"][debug report key]` to `url`.
+         1. Otherwise:
+            1. If `component win` is false and `processed response["server filtered debugging only reports"]`
+               does not contain `ad tech origin`, set
+               `processed response["server filtered debugging only reports"][ad tech origin]` to an empty list.
 1. Return `processed response`.
 
 #### Parsing reporting URLs {#response-parsing-reporting}

--- a/draft-ietf-bidding-and-auction-services.md
+++ b/draft-ietf-bidding-and-auction-services.md
@@ -779,6 +779,11 @@ response = {
   ; If not present, map as Null.
   ? buyerAndSellerReportingId: tstr,
 
+  ; Optional SelectedBuyerAndSellerReportingId of the winning Ad
+  ; Maps directly to https://wicg.github.io/turtledove/#server-auction-response-selected-buyer-and-seller-reporting-id
+  ; If not present, map as Null.
+  ? selectedBuyerAndSellerReportingId: tstr,
+
   ; The auction result may be ignored if set to true.
   ; Maps to https://wicg.github.io/turtledove/#server-auction-response-is-chaff.
   ; If not present, map as false.
@@ -992,11 +997,14 @@ response from Bidding and Auction Services. It takes as input the
      parsed as a [URL], returning failure if there is an error.
 1. If `response["adMetadata"]` exists and is a string set
    `processed response["ad metadata"]` to `response["adMetadata"]`.
-1. If `response["buyerReportingId"]` exists and is a string set
+1. If `response["buyerReportingId"]` exists and is a string, set
    `processed response["buyer reporting id"]` to `response["buyerReportingId"]`.
-1. If `response["buyerAndSellerReportingId"]` exists and is a string set
+1. If `response["buyerAndSellerReportingId"]` exists and is a string, set
    `processed response["buyer and seller reporting id"]` to
    `response["buyerAndSellerReportingId"]`.
+1. If `response["selectedBuyerAndSellerReportingId"]` exists and is a string, set
+   `processed response["selected buyer and seller reporting id"]` to
+   `response["selectedBuyerAndSellerReportingId"]`.
 1. If `response["debugReports"]` exists and is an array:
    1. For each `per origin debug reports` in `response["debugReports"]`:
       1. If `per origin debug reports["adTechOrigin"]` does not exist or

--- a/draft-ietf-bidding-and-auction-services.md
+++ b/draft-ietf-bidding-and-auction-services.md
@@ -1024,7 +1024,7 @@ response from Bidding and Auction Services. It takes as input the
                otherwise false.
             1. Set `debug report key["is debug win"]` to
                `report["isWinReport"]` if it exists and is a bool,
-               otherwise false. 
+               otherwise false.
             1. Set `processed response[
                "component win debugging only reports"][
                debug report key]` to `url`.

--- a/draft-ietf-bidding-and-auction-services.md
+++ b/draft-ietf-bidding-and-auction-services.md
@@ -999,33 +999,41 @@ response from Bidding and Auction Services. It takes as input the
    `response["buyerAndSellerReportingId"]`.
 1. If `response["debugReports"]` exists and is an array:
    1. For each `per origin debug reports` in `response["debugReports"]`:
-      1. If `per origin debug reports["adTechOrigin"]` does not exist or is not a string,
-         continue with the next iteration.
-      1. Let `ad tech origin` be `per origin debug reports["adTechOrigin"]` parsed as an [ORIGIN],
-         continue with the next iteration if there is an error.
-      1. If `per origin debug reports["reports"]` does not exist or is not an array,
-         continue with the next iteration.
+      1. If `per origin debug reports["adTechOrigin"]` does not exist or
+         is not a string, continue with the next iteration.
+      1. Let `ad tech origin` be `per origin debug reports[
+         "adTechOrigin"]` parsed as an [ORIGIN], continue with the next
+         iteration if there is an error.
+      1. If `per origin debug reports["reports"]` does not exist or is
+         not an array, continue with the next iteration.
       1. For each `report` in `per origin debug reports["reports"]`:
          1. If `report` is not a map, continue with the next iteration.
-         1. Let `component win` be `report["componentWin"]` if it exists and is a bool,
-            otherwise false.
+         1. Let `component win` be `report["componentWin"]` if it exists
+            and is a bool, otherwise false.
          1. If `report["url"]` exists and is a string:
-            1. Let `url` be `report["url"]` parsed as a [URL], or continue with the next
-               iteration if there is an error.
+            1. Let `url` be `report["url"]` parsed as a [URL], or
+               continue with the next iteration if there is an error.
             1. If `component win` is false, set
-               `processed response["server filtered debugging only reports"][ad tech origin]` to `url`,
-               and continue with the next iteration.
+               `processed response["server filtered debugging only
+               reports"][ad tech origin]` to `url`, and continue with
+               the next iteration.
             1. Let `debug report key` be a new structure analogous to
                [server auction debug report key](https://wicg.github.io/turtledove/#server-auction-debug-report-key).
-            1. Set `debug report key["from seller"]` to `report["isSellerReport"]` if it exists and is a bool,
+            1. Set `debug report key["from seller"]` to
+               `report["isSellerReport"]` if it exists and is a bool,
                otherwise false.
-            1. Set `debug report key["is debug win"]` to `report["isWinReport"]` if it exists and is a bool,
+            1. Set `debug report key["is debug win"]` to
+               `report["isWinReport"]` if it exists and is a bool,
                otherwise false. 
-            1. Set `processed response["component win debugging only reports"][debug report key]` to `url`.
+            1. Set `processed response[
+               "component win debugging only reports"][
+               debug report key]` to `url`.
          1. Otherwise:
-            1. If `component win` is false and `processed response["server filtered debugging only reports"]`
-               does not contain `ad tech origin`, set
-               `processed response["server filtered debugging only reports"][ad tech origin]` to an empty list.
+            1. If `component win` is false and `processed response[
+               "server filtered debugging only reports"]` does not
+               contain `ad tech origin`, set `processed response[
+               "server filtered debugging only reports"][
+               ad tech origin]` to an empty list.
 1. Return `processed response`.
 
 #### Parsing reporting URLs {#response-parsing-reporting}


### PR DESCRIPTION
... to support downsampling forDebuggingOnly reports. And send debug report's lockout status in the request as part of enableDebugReports field.